### PR TITLE
Alternative Stateful API

### DIFF
--- a/core/src/main/java/org/quicktheories/core/Configuration.java
+++ b/core/src/main/java/org/quicktheories/core/Configuration.java
@@ -14,6 +14,8 @@ public abstract class Configuration {
   private static final int DEFAULT_NO_ATTEMPTS = 10;
   private static final int DEFAULT_NO_EXAMPLES = 1000;
   private static final int DEFAULT_TESTING_TIME_MILLIS = -1;
+  private static final int DEFAULT_MIN_STATEFUL_STEPS = 1;
+  private static final int DEFAULT_MAX_STATEFUL_STEPS = 100;
 
   public final static String PROFILE = "QT_PROFILE";
   public final static String SEED = "QT_SEED";
@@ -55,8 +57,8 @@ public abstract class Configuration {
    * @return a Strategy
    */
   public static Strategy systemStrategy() {
-    return new Strategy(defaultPRNG(pickSeed()), pickExamples(), pickTestingTimeMillis(), pickShrinks(), pickAttempts(),
-        new ExceptionReporter(), pickGuidance());
+    return new Strategy(defaultPRNG(pickSeed()), pickExamples(), pickTestingTimeMillis(), pickShrinks(),
+            DEFAULT_MIN_STATEFUL_STEPS, DEFAULT_MAX_STATEFUL_STEPS, pickAttempts(), new ExceptionReporter(), pickGuidance());
   }
 
   private static int pickAttempts() {

--- a/core/src/main/java/org/quicktheories/core/Strategy.java
+++ b/core/src/main/java/org/quicktheories/core/Strategy.java
@@ -14,6 +14,8 @@ public class Strategy {
   private final int examples;
   private final long testingTimeMillis;
   private final int shrinkCycles;
+  private final int minStatefulSteps;
+  private final int maxStatefulSteps;
   private final Reporter reporter;
   private final Function<PseudoRandom, Guidance> guidance;
 
@@ -38,11 +40,14 @@ public class Strategy {
    *          Strategy to use to guide search
    */
   public Strategy(final PseudoRandom prng, final int examples, final long testingTimeMillis,
-      final int shrinkCycles, final int generateAttempts, Reporter reporter, Function<PseudoRandom, Guidance> guidance) {
+                  final int shrinkCycles,  final int minStatefulSteps, final int maxStatefulSteps, final int generateAttempts,
+                  Reporter reporter, Function<PseudoRandom, Guidance> guidance) {
     this.prng = prng;
     this.examples = examples;
     this.testingTimeMillis = testingTimeMillis;
     this.shrinkCycles = shrinkCycles;
+    this.minStatefulSteps = minStatefulSteps;
+    this.maxStatefulSteps = maxStatefulSteps;
     this.reporter = reporter;
     this.generateAttempts = generateAttempts;
     this.guidance = guidance;
@@ -78,7 +83,25 @@ public class Strategy {
   public int shrinkCycles() {
     return this.shrinkCycles;
   }
-  
+
+  /**
+   * Returns the minimum number of steps that will be generated in a run of a stateful model
+   *
+   * @return the minimum number of steps that will be generated in a run of a stateful model
+   */
+  public int minStatefulSteps() {
+    return this.minStatefulSteps;
+  }
+
+  /**
+   * Returns the maximum number of steps that will be generated in a run of a stateful model
+   *
+   * @return the maximum number of steps that will be generated in a run of a stateful model
+   */
+  public int maxStatefulSteps() {
+    return this.maxStatefulSteps;
+  }
+
   /**
    * Returns the maximum number of times to try to retrieve each value before giving up.
    * 
@@ -110,8 +133,8 @@ public class Strategy {
    *         supplied
    */
   public Strategy withFixedSeed(long seed) {
-    return new Strategy(defaultPRNG(seed), examples, testingTimeMillis, shrinkCycles, generateAttempts,
-        reporter, guidance);
+    return new Strategy(defaultPRNG(seed), examples, testingTimeMillis, shrinkCycles, minStatefulSteps, maxStatefulSteps,
+            generateAttempts, reporter, guidance);
   }
 
   /**
@@ -123,7 +146,8 @@ public class Strategy {
    * @return a strategy with the maximum number of examples as supplied
    */
   public Strategy withExamples(int examples) {
-    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, generateAttempts, reporter, guidance);
+    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, minStatefulSteps, maxStatefulSteps,
+            generateAttempts, reporter, guidance);
   }
 
   /**
@@ -145,7 +169,8 @@ public class Strategy {
    * @return a strategy with the testing time set to the amount of time given.
    */
   public Strategy withTestingTime(long time, TimeUnit timeUnit) {
-    return new Strategy(prng, examples, timeUnit.toMillis(time), shrinkCycles, generateAttempts, reporter, guidance);
+    return new Strategy(prng, examples, timeUnit.toMillis(time), shrinkCycles, minStatefulSteps, maxStatefulSteps,
+            generateAttempts, reporter, guidance);
   }
 
   /**
@@ -164,7 +189,8 @@ public class Strategy {
    * @return a strategy
    */
   public Strategy withGenerateAttempts(int generateAttempts) {
-    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, generateAttempts, reporter, guidance);
+    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, minStatefulSteps, maxStatefulSteps,
+            generateAttempts, reporter, guidance);
   }
   
   /**
@@ -173,7 +199,8 @@ public class Strategy {
    * @return a strategy
    */
   public Strategy withGuidance(Function<PseudoRandom, Guidance> guidance) {
-    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, generateAttempts, reporter, guidance);
+    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, minStatefulSteps, maxStatefulSteps,
+            generateAttempts, reporter, guidance);
   }
 
   /**
@@ -184,16 +211,30 @@ public class Strategy {
    * @return a strategy with the maximum number of shrinks as supplied
    */
   public Strategy withShrinkCycles(int shrinks) {
-    return new Strategy(prng, examples, testingTimeMillis, shrinks, generateAttempts, reporter, guidance);
+    return new Strategy(prng, examples, testingTimeMillis, shrinks, minStatefulSteps, maxStatefulSteps,
+            generateAttempts, reporter, guidance);
   }
-  
+
+  public Strategy withMinStatefulSteps(int minStatefulSteps)
+  {
+    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, minStatefulSteps, maxStatefulSteps,
+            generateAttempts, reporter, guidance);
+  }
+
+  public Strategy withMaxStatefulSteps(int maxStatefulSteps)
+  {
+    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, minStatefulSteps, maxStatefulSteps,
+            generateAttempts, reporter, guidance);
+  }
+
   /**
    * Creates a strategy using the supplied reporter
    * @param reporter Reporter to use
    * @return a strategy with suppled reporter
    */
   public Strategy withReporter(Reporter reporter) {
-    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, generateAttempts, reporter, guidance);
+    return new Strategy(prng, examples, testingTimeMillis, shrinkCycles, minStatefulSteps, maxStatefulSteps,
+            generateAttempts, reporter, guidance);
   }
 
   /**

--- a/core/src/main/java/org/quicktheories/impl/stateful/StatefulCore.java
+++ b/core/src/main/java/org/quicktheories/impl/stateful/StatefulCore.java
@@ -1,0 +1,59 @@
+package org.quicktheories.impl.stateful;
+
+import org.quicktheories.core.Gen;
+import org.quicktheories.core.RandomnessSource;
+import org.quicktheories.core.Strategy;
+import org.quicktheories.generators.Generate;
+import org.quicktheories.impl.Constraint;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+/**
+ * Drives a {@link StatefulTheory}
+ */
+public class StatefulCore<T> {
+
+    private final RandomnessSource prng;
+    private final StatefulTheory<T> theory;
+
+    public static Gen<StatefulCore> generator(Supplier<StatefulTheory<?>> theory) {
+        Gen<StatefulCore> gen = prng -> {
+            // swallow a random value so that hashes of each StatefulCore differ
+            // (hashes are based on the prng not the value)
+            prng.next(Constraint.none());
+            return new StatefulCore<>(prng, theory.get());
+        };
+        return gen.describedAs(c -> c.theory.formattedHistory());
+    }
+
+
+    private StatefulCore(RandomnessSource prng, StatefulTheory<T> theory) {
+        this.prng = prng;
+        this.theory = theory;
+    }
+
+    public boolean run(Supplier<Strategy> state) {
+        theory.init();
+        Iterator<Gen<T>> setupSteps = theory.setupSteps();
+        while (setupSteps.hasNext()) {
+            theory.executeStep(setupSteps.next().generate(prng));
+        }
+
+        Strategy strategy = state.get();
+        int numSteps = Generate.longRange(strategy.minStatefulSteps(), strategy.maxStatefulSteps(), strategy.minStatefulSteps())
+                               .map(Long::intValue)
+                               .generate(prng);
+        try {
+            for (int i = 0; i < numSteps; i++) {
+                if (!theory.executeStep(theory.steps().generate(prng))) {
+                    return false;
+                }
+            }
+        } finally {
+            theory.teardown();
+        }
+
+        return true;
+    }
+}

--- a/core/src/main/java/org/quicktheories/impl/stateful/StatefulTheory.java
+++ b/core/src/main/java/org/quicktheories/impl/stateful/StatefulTheory.java
@@ -1,0 +1,362 @@
+package org.quicktheories.impl.stateful;
+
+import org.quicktheories.api.Pair;
+import org.quicktheories.core.Gen;
+import org.quicktheories.generators.Generate;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Main interface and implementation for Stateful QuickTheories tests.
+ *
+ * See {@link WithHistory} and {@link StepBased} for more information and examples.
+ */
+public interface StatefulTheory<T> {
+
+    default Iterator<Gen<T>> setupSteps() {
+        return Collections.emptyIterator();
+    }
+
+    Gen<T> steps();
+
+    boolean executeStep(T s);
+
+    default void init() {}
+
+    default void teardown() {}
+
+    default List<T> history() {
+        return new ArrayList<>();
+    }
+
+    default String formattedHistory() {
+        int i = 0;
+        StringBuilder builder = new StringBuilder();
+
+        for (T step : history()) {
+            builder.append(String.format("%sS%d = %s",
+                                         i == 0 ? "" : "\n", i + 1, step.toString()));
+            i++;
+        }
+
+        return builder.toString();
+    }
+
+    abstract class WithHistory<T> implements StatefulTheory<T> {
+        private final List<T> history = new ArrayList<T>();
+
+        public abstract boolean performStep(T s);
+
+        public boolean executeStep(T s) {
+            history.add(s);
+            return performStep(s);
+        }
+
+        @Override
+        public List<T> history() {
+            return Collections.unmodifiableList(history);
+        }
+    }
+
+    /**
+     * Step Based module allows to build complex models by sharing state between steps.
+     *
+     * This state can be used for validation as well as for generating input for future steps.
+     * For example, if we were to model a hashmap, step validating removals can information
+     * about already inserted keys.
+     */
+    abstract class StepBased extends WithHistory<Step> {
+        private final List<Gen<Step>> setupSteps = new ArrayList<>();
+        private final List<Pair<Integer, Gen<Step>>> steps = new ArrayList<>();
+
+        /**
+         * Returns setup steps added during {@link StepBased#initSteps()}.
+         */
+        public Iterator<Gen<Step>> setupSteps() {
+            return setupSteps.iterator();
+        }
+
+        public Gen<Step> steps() {
+            return Generate.frequencyWithNoShrinkPoint(steps).assuming(Objects::nonNull);
+        }
+
+        public boolean performStep(Step s) {
+            try {
+                s.run();
+            } catch (Throwable t) {
+                return false; // failure handled by StatefulCore
+            }
+
+            return s.postConditionValid();
+        }
+
+        /**
+         * Add setup step for this theory.
+         *
+         * Setup steps are executed _before_ regular steps are executed, _in the order they were added_.
+         * Each setup step is executed _only once_.
+         *
+         * State can be shared between all steps (setup and regular ones).
+         */
+        protected void addSetupStep(Gen<Step> step) {
+            setupSteps.add(step);
+        }
+
+        /**
+         * Add step for this theory.
+         *
+         * Step is an execution and validation unit for theory. State is available in step
+         * runnable as well as in its generator suppliers, pre- and post-conditions.
+         */
+        protected void addStep(Gen<Step> step) {
+            addStep(1, step);
+        }
+
+        /**
+         * Add <i>weighted</i> step for this theory.
+         *
+         * Same as {@link StepBased#addStep(Gen)}, but allowing to assign weight for each step.
+         * Weight is assigned proportionally (i.e. when adding two steps with weights 50 and 100,
+         * former one will be executed half as often as latter one, on average).
+         *
+         * See {@link Generate#frequencyWithNoShrinkPoint(List)}.
+         */
+        protected void addStep(int weight, Gen<Step> step) {
+            steps.add(Pair.of(weight, step));
+        }
+
+        public void init() {
+            initSteps();
+        }
+
+        /**
+         * Add steps so this step-based theory by calling {@link StepBased#addStep(Gen)} to add
+         * regular steps and {@link StepBased#addSetupStep(Gen)} to add setup steps.
+         */
+        protected abstract void initSteps();
+
+    }
+
+    class Step {
+        protected final String desc;
+        protected final String argString;
+        protected final Supplier<Boolean> precondition;
+        protected final Supplier<Boolean> postcondition;
+        protected final Runnable action;
+
+        public Step(String desc,
+                    String argString,
+                    Runnable action,
+                    Supplier<Boolean> precondition,
+                    Supplier<Boolean> postcondition) {
+            this.desc = desc;
+            this.argString = argString;
+            this.precondition = precondition;
+            this.postcondition = postcondition;
+            this.action = action;
+        }
+
+        public void run() {
+            action.run();
+        }
+
+        public boolean postConditionValid() {
+            return postcondition == null ? true : postcondition.get();
+        }
+
+
+        @Override
+        public String toString() {
+            return desc + "(" + argString() + ")";
+        }
+
+        public String argString() {
+            return argString;
+        }
+    }
+
+    abstract class StepBuilder {
+        protected final String desc;
+        protected Supplier<Boolean> precondition;
+        protected Supplier<Boolean> postcondition;
+
+        public StepBuilder(String desc) {
+            this.desc = desc;
+        }
+
+        protected boolean allowed() {
+            return precondition == null || precondition.get();
+        }
+
+        /**
+         * Precondition that has to be fulfilled in order for step to run.
+         *
+         * If supplier returns {@code false}, step will be skipped and its
+         * postcondition will not be run even if it is supplied.
+         */
+        public StepBuilder precondition(Supplier<Boolean> precondition) {
+            this.precondition = precondition;
+            return this;
+        }
+
+        public StepBuilder postcondition(Supplier<Boolean> postcondition) {
+            this.postcondition = postcondition;
+            return this;
+        }
+
+        public abstract Gen<Step> build();
+    }
+
+    public static StepBuilder builder(String desc, Runnable action) {
+        return new StepBuilder(desc) {
+            @Override
+            public Gen<Step> build() {
+                return (in) -> {
+                    if (!allowed())
+                        return null;
+
+                    return new Step(desc, "", action, precondition, postcondition);
+                };
+            }
+        };
+    }
+
+    public static <T1> StepBuilder builder(String desc, Consumer<T1> action, Gen<T1> g1) {
+        return builder(desc, action, () -> g1);
+    }
+
+    public static <T1> StepBuilder builder(String desc, Consumer<T1> action, Supplier<Gen<T1>> s1) {
+        return new StepBuilder(desc) {
+            @Override
+            public Gen<Step> build() {
+                return (in) -> {
+                    if (!allowed())
+                        return null;
+
+                    Gen<T1> g1 = s1.get();
+                    T1 arg1 = g1.generate(in);
+                    return new Step(desc, g1.asString(arg1), () -> action.accept(arg1), precondition, postcondition);
+                };
+            }
+        };
+    }
+
+    public static <T1, T2> StepBuilder builder(String desc,
+                                               BiConsumer<T1, T2> action,
+                                               Gen<T1> g1,
+                                               Gen<T2> g2) {
+        return builder(desc, action, () -> g1, () -> g2);
+    }
+
+    public static <T1, T2> StepBuilder builder(String desc,
+                                               BiConsumer<T1, T2> action,
+                                               Supplier<Gen<T1>> s1,
+                                               Supplier<Gen<T2>> s2) {
+        return new StepBuilder(desc) {
+            @Override
+            public Gen<Step> build() {
+                return (in) -> {
+                    if (!allowed())
+                        return null;
+
+                    Gen<T1> g1 = s1.get();
+                    Gen<T2> g2 = s2.get();
+                    T1 arg1 = g1.generate(in);
+                    T2 arg2 = g2.generate(in);
+                    return new Step(desc, StatefulTheory.buildArgString(g1.asString(arg1), g2.asString(arg2)),
+                                    () -> action.accept(arg1, arg2), precondition, postcondition);
+                };
+            }
+        };
+    }
+
+    public interface TriConsumer<T1, T2, T3> {
+        public void accept(T1 t1, T2 t2, T3 t3);
+    }
+
+    public static <T1, T2, T3> StepBuilder builder(String desc,
+                                                   TriConsumer<T1, T2, T3> action,
+                                                   Gen<T1> g1,
+                                                   Gen<T2> g2,
+                                                   Gen<T3> g3) {
+        return builder(desc, action, () -> g1, () -> g2, () -> g3);
+    }
+
+    public static <T1, T2, T3> StepBuilder builder(String desc,
+                                                   TriConsumer<T1, T2, T3> action,
+                                                   Supplier<Gen<T1>> s1,
+                                                   Supplier<Gen<T2>> s2,
+                                                   Supplier<Gen<T3>> s3) {
+        return new StepBuilder(desc) {
+            @Override
+            public Gen<Step> build() {
+                return (in) -> {
+                    if (!allowed())
+                        return null;
+
+                    Gen<T1> g1 = s1.get();
+                    Gen<T2> g2 = s2.get();
+                    Gen<T3> g3 = s3.get();
+                    T1 arg1 = g1.generate(in);
+                    T2 arg2 = g2.generate(in);
+                    T3 arg3 = g3.generate(in);
+                    return new Step(desc,
+                                    StatefulTheory.buildArgString(g1.asString(arg1), g2.asString(arg2), g3.asString(arg3)),
+                                    () -> action.accept(arg1, arg2, arg3),
+                                    precondition, postcondition);
+                };
+            }
+        };
+    }
+
+    public interface QuadConsumer<T1, T2, T3, T4> {
+        public void accept(T1 t1, T2 t2, T3 t3, T4 t4);
+    }
+
+    public static <T1, T2, T3, T4> StepBuilder builder(String desc,
+                                                       QuadConsumer<T1, T2, T3, T4> action,
+                                                       Gen<T1> g1,
+                                                       Gen<T2> g2,
+                                                       Gen<T3> g3,
+                                                       Gen<T4> g4) {
+        return builder(desc, action, () -> g1, () -> g2, () -> g3, () -> g4);
+    }
+
+    public static <T1, T2, T3, T4> StepBuilder builder(String desc,
+                                                       QuadConsumer<T1, T2, T3, T4> action,
+                                                       Supplier<Gen<T1>> s1,
+                                                       Supplier<Gen<T2>> s2,
+                                                       Supplier<Gen<T3>> s3,
+                                                       Supplier<Gen<T4>> s4) {
+        return new StepBuilder(desc) {
+            @Override
+            public Gen<Step> build() {
+                return (in) -> {
+                    if (!allowed())
+                        return null;
+
+                    Gen<T1> g1 = s1.get();
+                    Gen<T2> g2 = s2.get();
+                    Gen<T3> g3 = s3.get();
+                    Gen<T4> g4 = s4.get();
+                    T1 arg1 = g1.generate(in);
+                    T2 arg2 = g2.generate(in);
+                    T3 arg3 = g3.generate(in);
+                    T4 arg4 = g4.generate(in);
+                    return new Step(desc,
+                                    StatefulTheory.buildArgString(g1.asString(arg1), g2.asString(arg2),
+                                                                  g3.asString(arg3), g4.asString(arg4)),
+                                    () -> action.accept(arg1, arg2, arg3, arg4),
+                                    precondition, postcondition);
+                };
+            }
+        };
+    }
+
+    static String buildArgString(String... objects) {
+        return String.join(", ", objects);
+    }
+}

--- a/core/src/test/java/com/example/StatefulMapExample.java
+++ b/core/src/test/java/com/example/StatefulMapExample.java
@@ -1,0 +1,103 @@
+package com.example;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.quicktheories.WithQuickTheories;
+import org.quicktheories.api.Pair;
+import org.quicktheories.core.Gen;
+import org.quicktheories.impl.stateful.StatefulTheory;
+
+import java.util.*;
+import static org.quicktheories.impl.stateful.StatefulTheory.*;
+
+public class StatefulMapExample implements WithQuickTheories {
+
+    /* Stateful test example - a buggy dictionary that does not insert
+    ** any keys that contain the letter 'z'. The model of the dictionary
+    ** is just a simple list of pairs that gets searched for the key in
+    ** the first element.  On update, any existing pair is removed and
+    ** then a new pair is created and added to the list.
+    */
+
+    @Test
+    public void test() {
+        qt().withMinStatefulSteps(2).withMaxStatefulSteps(100).stateful(StepBasedMapModel::new);
+    }
+
+    class StepBasedMapModel extends StatefulTheory.StepBased {
+
+        private List<Pair<String, String>> state = null;
+        private Map<String, String> map = null;
+
+        void setup() {
+            state = new LinkedList<>();
+            map = new BuggyMap();
+        }
+
+        void is_empty() {
+            assert (state.isEmpty() == map.isEmpty());
+        }
+
+        void get(String key) {
+            String val = map.get(key);
+            String expect = null;
+            for (Pair<String, String> pair : state) {
+                if (key.equals(pair._1)) {
+                    expect = pair._2;
+                    break;
+                }
+            }
+            if (expect == null)
+                assert val == null;
+            else
+                assert expect.equals(val);
+        }
+
+        void put(String key, String val) {
+            String result = map.put(key, val);
+
+            Pair<String,String> statePair = null;
+            for (Pair<String, String> pair : state) {
+                if (key.equals(pair._1)) {
+                    statePair = pair;
+                    break;
+                }
+            }
+            if (statePair != null) {
+                state.remove(statePair);
+            }
+            state.add(Pair.of(key,val));
+
+            if (statePair == null)
+                assert result == null;
+            else
+                assert result != null && result.equals(statePair._2);
+        }
+
+        protected void initSteps() {
+            // Generators are here to avoid initialization order issues with
+            // defining them as values in the class body.
+            Gen<String> keys = strings().betweenCodePoints('a', 'z').ofLengthBetween(1, 3);
+            Gen<String> vals = strings().basicLatinAlphabet().ofLengthBetween(0, 100);
+
+            addSetupStep(builder("setup", this::setup).build());
+
+            addStep(builder("is_empty", this::is_empty).build());
+            addStep(3, builder("get", this::get, keys).build());
+            addStep(6, builder("put", this::put, keys, vals).build());
+        }
+    }
+
+     class BuggyMap extends HashMap<String, String> {
+        public String put(String key, String value) {
+            if (key.contains("z")) {
+                return null;
+            } else {
+                return super.put(key, value);
+            }
+        }
+        BuggyMap() {
+            super();
+        }
+    }
+}

--- a/core/src/test/java/org/quicktheories/highlevel/ComponentTest.java
+++ b/core/src/test/java/org/quicktheories/highlevel/ComponentTest.java
@@ -20,7 +20,7 @@ import org.quicktheories.dsl.TheoryBuilder;
 abstract class ComponentTest<T> {
   
   protected Reporter reporter = mock(Reporter.class);
-  protected Strategy defaultStrategy = new Strategy(Configuration.defaultPRNG(2), 1000, 0, 10000, 10,
+  protected Strategy defaultStrategy = new Strategy(Configuration.defaultPRNG(2), 1000, 0, 10000, 1, 10, 10,
       this.reporter, prng -> new NoGuidance());
 
   public TheoryBuilder<T> assertThatFor(Gen<T> generator) {

--- a/core/src/test/java/org/quicktheories/highlevel/IntegersComponentTest.java
+++ b/core/src/test/java/org/quicktheories/highlevel/IntegersComponentTest.java
@@ -63,7 +63,7 @@ public class IntegersComponentTest extends ComponentTest<Integer> implements Wit
   public void shouldFindAValueEqualToTargetWithDomainBelowZeroMarker() {
     int target = -1;
     assertThatFor(integers().from(-6).upToAndIncluding(-1),
-        new Strategy(Configuration.defaultPRNG(0), 1, 0, 2, 1, this.reporter, prng -> new NoGuidance()))
+        new Strategy(Configuration.defaultPRNG(0), 1, 0, 2, 1, 10, 1, this.reporter, prng -> new NoGuidance()))
             .check(i -> i > target);
     smallestValueIsEqualTo(target);
   }

--- a/core/src/test/java/org/quicktheories/impl/QTTester.java
+++ b/core/src/test/java/org/quicktheories/impl/QTTester.java
@@ -31,7 +31,7 @@ public class QTTester {
   private Reporter r = mock(Reporter.class);
 
   public QuickTheory qt(long seed) {
-    Strategy s = new Strategy(Configuration.defaultPRNG(seed), 100, 0, 10000, 10, r, prng -> new NoGuidance());
+    Strategy s = new Strategy(Configuration.defaultPRNG(seed), 100, 0, 10000, 1, 10, 10, r, prng -> new NoGuidance());
     return org.quicktheories.QuickTheory.qt(() -> s);
   }
 

--- a/core/src/test/java/org/quicktheories/impl/TheoryRunnerTest.java
+++ b/core/src/test/java/org/quicktheories/impl/TheoryRunnerTest.java
@@ -45,7 +45,7 @@ public class TheoryRunnerTest {
 
   @Before
   public void setup() {
-    strategy = new Strategy(Configuration.defaultPRNG(0), 100, 0, 100, 10, reporter, guidance);
+    strategy = new Strategy(Configuration.defaultPRNG(0), 100, 0, 100, 1, 10, 10, reporter, guidance);
   }
 
   @Test
@@ -106,7 +106,7 @@ public class TheoryRunnerTest {
   @Test
   public void shouldReportInitialSeed() {
     long seed = 42;
-    strategy = new Strategy(Configuration.defaultPRNG(seed), 10, 0, 10, 10, reporter, guidance);
+    strategy = new Strategy(Configuration.defaultPRNG(seed), 10, 0, 10, 1, 10, 10, reporter, guidance);
     testee = makeTesteeFor(arbitrary().pick(1));
     testee.check(i -> false);
     verify(reporter, times(1)).falisification(eq(seed), anyInt(), anyInt(),
@@ -123,7 +123,7 @@ public class TheoryRunnerTest {
   @Test
   public void shouldReportNumberOfFoundExamplesWhenValuesExhausted() {
     int numberOfExamples = 3;
-    strategy = new Strategy(Configuration.defaultPRNG(0), numberOfExamples, 0, 0, 10,
+    strategy = new Strategy(Configuration.defaultPRNG(0), numberOfExamples, 0, 0, 1, 10, 10,
         reporter, guidance);
     testee = makeTesteeFor(
         arbitrary().pick(1, 2, 1, 1, 1).assuming(

--- a/core/src/test/java/org/quicktheories/impl/stateful/StatefulTest.java
+++ b/core/src/test/java/org/quicktheories/impl/stateful/StatefulTest.java
@@ -1,0 +1,142 @@
+package org.quicktheories.impl.stateful;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.quicktheories.WithQuickTheories;
+import org.quicktheories.core.Gen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.quicktheories.impl.stateful.StatefulTheory.builder;
+
+public class StatefulTest implements WithQuickTheories {
+
+    @Test
+    public void testStatefulInitialization() {
+        AtomicInteger counter = new AtomicInteger();
+
+        qt().withMinStatefulSteps(100)
+                .withMaxStatefulSteps(100)
+                .withExamples(1)
+                .stateful(() -> new StatefulTheory.StepBased() {
+                    @Override
+                    protected void initSteps() {
+                        counter.incrementAndGet();
+                        addStep(builder("test1", () -> {}).build());
+                    }
+                });
+        Assert.assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void testMinMaxSteps() {
+        qt().forAll(integers().between(1, 10), integers().between(11, 100))
+                .checkAssert( (min, max) -> {
+                    List<AtomicInteger> counts = new ArrayList<>(10);
+                    qt().withMinStatefulSteps(min)
+                            .withMaxStatefulSteps(max)
+                            .withExamples(10)
+                            .stateful(() -> new StatefulTheory.StepBased() {
+                                @Override
+                                protected void initSteps() {
+                                    AtomicInteger counter = new AtomicInteger();
+                                    addSetupStep(builder("addToList", () -> counts.add(counter)).build());
+                                    addStep(builder("test1", () -> counter.incrementAndGet()).build());
+                                }
+                            });
+
+                    for (AtomicInteger counter : counts) {
+                        int ranSteps = counter.get();
+                        Assert.assertTrue(ranSteps >= min && ranSteps <= max);
+                    }
+                });
+    }
+
+    @Test
+    public void testPreConditions() {
+        AtomicInteger counter = new AtomicInteger();
+        Supplier<Boolean> alwaysFalse = () -> false;
+
+        Supplier<Gen<Runnable>> supplier = () -> {
+            counter.incrementAndGet();
+            return (in) -> () -> {};
+        };
+
+        Supplier<Boolean> postcondition = () -> {
+            counter.incrementAndGet();
+            return false;
+        };
+
+        try {
+            // Generator supplier should not be called if preconditions is not met
+            qt().withStatefulModel(() -> new StatefulTheory.StepBased() {
+                @Override
+                protected void initSteps() {
+                    addStep(builder("test1", (a) -> counter.incrementAndGet(),
+                                    supplier)
+                                    .precondition(alwaysFalse)
+                                    .postcondition(postcondition)
+                                    .build());
+
+                    addStep(builder("test2", (a1, a2) -> counter.incrementAndGet(),
+                                    supplier, supplier)
+                                    .precondition(alwaysFalse)
+                                    .postcondition(postcondition)
+                                    .build());
+
+                    addStep(builder("test3", (a1, a2, a3) -> counter.incrementAndGet(),
+                                    supplier, supplier, supplier)
+                                    .precondition(alwaysFalse)
+                                    .postcondition(postcondition)
+                                    .build());
+
+                    addStep(builder("test4", (a1, a2, a3, a4) -> counter.incrementAndGet(),
+                                    supplier, supplier, supplier, supplier)
+                                    .precondition(alwaysFalse)
+                                    .postcondition(postcondition)
+                                    .build());
+                }
+            }).checkStateful();
+        } catch (AssertionError t) {
+            // ignore;
+        }
+
+        Assert.assertEquals(0, counter.get());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testPostCondition() {
+        qt().stateful(() -> new StatefulTheory.StepBased() {
+            @Override
+            protected void initSteps() {
+                addStep(builder("test1", () -> {
+                }).postcondition(() -> false).build());
+            }
+        });
+    }
+
+    /*
+    @Test
+    public void argStringTest() {
+        Gen<StatefulTheory.Step> step = builder("test1",
+                                                (a1) -> {},
+                                                (in) -> 1).build();
+        Assert.assertEquals("test1(1)",
+                            step.example().toString());
+        step = builder("test2",
+                       (a1, a2) -> {},
+                       (in) -> 1, (in) -> 2).build();
+        Assert.assertEquals("test2(1, 2)", step.example().toString());
+        step = builder("test3",
+                       (a1, a2, a3) -> {},
+                       (in) -> 1, (in) -> 2, (in) -> 3).build();
+        Assert.assertEquals("test3(1, 2, 3)", step.example().toString());
+        step = builder("test4",
+                       (a1, a2, a3, a4) -> {},
+                       (in) -> 1, (in) -> 2, (in) -> 3, (in) -> 4).build();
+        Assert.assertEquals("test4(1, 2, 3, 4)", step.example().toString());
+    }*/
+}


### PR DESCRIPTION
This PR adds an alternative API for writing stateful property-based tests. It provides the following features:

* Ability to write tests that have a randomly generated series of actions in addition to randomly generated inputs for those actions
* Track state during the test and base the generation of actions and inputs on the current state
* Allows selectable actions to be filtered by a precondition
* Validation can be performed within the action or in postconditions. 
* Provides convenient high-level API as well as low-level API that can be integrated with the existing stateful API


Examples can be found in:

* com.example.StatefulMapExample
* com.example.StatefulTest

Other notes:

* One of the tests is currently commented out because it depends on #50  