### PR TITLE
Clear error message for .pick from empty list

### DIFF
--- a/core/src/main/java/org/quicktheories/generators/Generate.java
+++ b/core/src/main/java/org/quicktheories/generators/Generate.java
@@ -59,6 +59,9 @@ public class Generate {
    * @return A Gen of T
    */
   public static <T> Gen<T> pick(List<T> ts) {
+    if (ts.isEmpty()) {
+      throw new IllegalArgumentException("Cannot pick elements of an empty list");
+    }
     Gen<Integer> index = range(0, ts.size() - 1);
     return prng -> ts.get(index.generate(prng));
   }

--- a/core/src/test/java/org/quicktheories/generators/GenerateTest.java
+++ b/core/src/test/java/org/quicktheories/generators/GenerateTest.java
@@ -1,5 +1,6 @@
 package org.quicktheories.generators;
 
+import static org.junit.Assert.fail;
 import static org.quicktheories.impl.GenAssert.assertThatGenerator;
 
 import java.util.ArrayList;
@@ -87,5 +88,14 @@ public class GenerateTest {
         Pair.of(10, Generate.constant(2)),
         Pair.of(100, Generate.constant(3)));
     assertThatGenerator(testee).hasNoShrinkPoint();
+  }
+
+  @Test
+  public void shouldThrowErrorWhenPickingFromEmptyList() {
+    try {
+      Gen<Integer> testee = Generate.pick(new ArrayList<Integer>());
+      fail("Attempted to pick from an empty list!");
+    } catch (IllegalArgumentException expected) {
+    }
   }
 }


### PR DESCRIPTION
Currently, attempting to `Generate.pick` from an empty list will fail, but with a somewhat confusing message about an illegal range from -1 to 0. This error message should be much clearer.