### PR TITLE
Implement excludingRange and withRange functionality for Strings

### DIFF
--- a/core/src/main/java/org/quicktheories/generators/Strings.java
+++ b/core/src/main/java/org/quicktheories/generators/Strings.java
@@ -1,10 +1,39 @@
 package org.quicktheories.generators;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.function.Function;
 
+import org.quicktheories.api.Pair;
 import org.quicktheories.core.Gen;
 
 final class Strings {
+
+  static Gen<String> fromRanges(List<Pair<Integer, Integer>> ranges, int minLength, int maxLength) {
+      ranges = new ArrayList<>(ranges);
+      // Sorting by range size seems like it ought to reduce the frequency with which we have to bump the percentage up
+      // from zero below
+      ranges.sort(Comparator.comparing(r -> r._2 - r._1));
+      Pair<Integer, Integer> first = ranges.get(0);
+      Gen<Integer> gen = CodePoints.codePoints(first._1, first._2);
+      int total = 1 + ranges.get(0)._2 - ranges.get(0)._1;
+      for (int i = 1; i < ranges.size(); i++) {
+          Pair<Integer, Integer> next = ranges.get(i);
+          Gen<Integer> gen2 = CodePoints.codePoints(next._1, next._2);
+          int nextSize = 1 + next._2 - next._1;
+          int weight = (int) (100 * ((float) total / (total + nextSize)));
+          if (weight == 0) {
+              weight = 1;
+          }
+          weight = 100 - weight;
+          total = total + nextSize;
+          gen = gen.mix(gen2, weight);
+      }
+      return Generate.intArrays(Generate.range(minLength, maxLength)
+              , gen)
+              .map(is -> new String(is, 0, is.length)).map(reduceToSize(maxLength));
+  }
 
   static Gen<String> boundedNumericStrings(int startInclusive,
       int endInclusive) {

--- a/core/src/test/java/org/quicktheories/generators/StringsTest.java
+++ b/core/src/test/java/org/quicktheories/generators/StringsTest.java
@@ -4,8 +4,6 @@ import static org.quicktheories.impl.GenAssert.assertThatGenerator;
 
 import org.junit.Test;
 import org.quicktheories.core.Gen;
-import org.quicktheories.generators.Generate;
-import org.quicktheories.generators.Strings;
 
 public class StringsTest {
 
@@ -41,6 +39,18 @@ public class StringsTest {
     Gen<String> testee = Strings.withCodePoints(
         BASIC_LATIN_FIRST_CODEPOINT, BASIC_LATIN_LAST_CODEPOINT, Generate.constant(3));
     assertThatGenerator(testee).shrinksTowards("!!!");
+  }
+
+  @Test
+  public void shouldIncludeLettersAndNumbersForAlphaNumeric() {
+      Gen<String> testee = new StringsDSL().betweenCodePoints(48, 57).withRange(65, 91).ofLength(1);
+      assertThatGenerator(testee).generatesAllOf("0", "A");
+  }
+
+  @Test
+  public void shouldNotIgnoreSmallRange() {
+    Gen<String> testee = new StringsDSL().betweenCodePoints(48, 48).withRange(256, 0xD7FB).ofLength(1);
+    assertThatGenerator(testee).generatesAllOf("0");
   }
 
 }


### PR DESCRIPTION
This is a work in progress PR related to Issue 38 https://github.com/quicktheories/QuickTheories/issues/38

If the direction seems reasonable, I would still need to implement the `excludingRanges` method but it's clear enough how to do that. 